### PR TITLE
Fix für Postgresql-Datenbankfehler

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -73,7 +73,7 @@ class mod_publication_mod_form extends moodleform_mod{
         $mform->addElement('header','publication', get_string('modulename','publication'));
         $mform->setExpanded('publication');
         
-        if(isset($this->current->id)){
+        if(isset($this->current->id) && !empty($this->current->id)){
         	$filecount = $DB->count_records('publication_file', array('publication'=>$this->current->id));
         }
         


### PR DESCRIPTION
Fix für Datenbankfehler (unter Postgresql) beim Anlegen eines neuen Studierendenordners

Fehler war:
```
Default exception handler: Fehler beim Lesen der Datenbank Debug: ERROR:  invalid input syntax for integer: ""\nSELECT COUNT('x') FROM mdl_publication_file WHERE publication = $1\n[array (\n  0 => '',\n)]
Error code: dmlreadexception
* line 443 of /lib/dml/moodle_database.php: dml_read_exception thrown
* line 244 of /lib/dml/pgsql_native_moodle_database.php: call to moodle_database->query_end()
* line 764 of /lib/dml/pgsql_native_moodle_database.php: call to pgsql_native_moodle_database->query_end()
* line 1476 of /lib/dml/moodle_database.php: call to pgsql_native_moodle_database->get_records_sql()
* line 1549 of /lib/dml/moodle_database.php: call to moodle_database->get_record_sql()
* line 1759 of /lib/dml/moodle_database.php: call to moodle_database->get_field_sql()
* line 1742 of /lib/dml/moodle_database.php: call to moodle_database->count_records_sql()
* line 1725 of /lib/dml/moodle_database.php: call to moodle_database->count_records_select()
* line 77 of /mod/publication/mod_form.php: call to moodle_database->count_records()
* line 191 of /lib/formslib.php: call to mod_publication_mod_form->definition()
* line 86 of /course/moodleform_mod.php: call to moodleform->moodleform()
* line 254 of /course/modedit.php: call to moodleform_mod->moodleform_mod()
```
Beim Anlegen einer neuen Aktivität ist die Variable `$this->current->id` noch nicht belegt, jedoch bereits existent. Dadurch wird die if-Bedingung wahr und der Code mit der Datenbankabfrage ausgeführt. Dies resultiert bei uns in einem Fehler.
Abhilfe schaffte die zusätzliche Bedingung, dass die Variable nicht leer sein darf.