### PR TITLE
Omit manager in recieveteachernotification cap

### DIFF
--- a/db/access.php
+++ b/db/access.php
@@ -85,8 +85,7 @@ $capabilities = [
             'contextlevel' => CONTEXT_MODULE,
             'archetypes' => [
                 'teacher' => CAP_ALLOW,
-                'editingteacher' => CAP_ALLOW,
-                'manager' => CAP_ALLOW
+                'editingteacher' => CAP_ALLOW
             ]
         ],
 ];


### PR DESCRIPTION
PR for https://github.com/academic-moodle-cooperation/moodle-mod_publication/issues/38

TLDR:
The manager role should not have the capability "mod/publication:recieveteachernotification" by default,
because a manager is usually not involved in day to day activities and should therefor not be bothered by notifications.

