### PR TITLE
Added webservice-functions to mod_publication

### DIFF
--- a/db/services.php
+++ b/db/services.php
@@ -46,4 +46,23 @@ $functions = [
            'type' => 'read', // Database rights of the WS-function (read, write).
            'ajax' => true,
         ],
+
+    'mod_publication_get_publications_by_courses' => [
+        'classname'     => 'mod_publication_external',
+        'methodname'    => 'get_publications_by_courses',
+        'classpath'     => 'mod/publication/externallib.php',
+        'description'   => 'Get all publications for the given courses',
+        'type'          => 'read',
+        'services'      => [MOODLE_OFFICIAL_MOBILE_SERVICE],
+    ],
+
+    'mod_publication_get_publication' => [
+        'classname'     => 'mod_publication_external',
+        'methodname'    => 'get_publication',
+        'classpath'     => 'mod/publication/externallib.php',
+        'description'   => 'Get the publication with the given id',
+        'type'          => 'read',
+        'services'      => [MOODLE_OFFICIAL_MOBILE_SERVICE],
+    ],
+
 ];

--- a/externallib.php
+++ b/externallib.php
@@ -50,10 +50,10 @@ class mod_publication_external extends external_api {
         // The external_function_parameters constructor expects an array of external_description.
         return new external_function_parameters(
         // An external_description can be: external_value, external_single_structure or an external_multiple structure!
-                [
-                        'itemid' => new external_value(PARAM_INT, 'Group\'s or user\'s ID'),
-                        'cmid' => new external_value(PARAM_INT, 'Coursemodule ID')
-                ]
+            [
+                'itemid' => new external_value(PARAM_INT, 'Group\'s or user\'s ID'),
+                'cmid' => new external_value(PARAM_INT, 'Coursemodule ID')
+            ]
         );
     }
 
@@ -70,10 +70,10 @@ class mod_publication_external extends external_api {
 
         // Parameters validation!
         $params = self::validate_parameters(self::get_onlinetextpreview_parameters(),
-                [
-                        'itemid' => $itemid,
-                        'cmid' => $cmid
-                ]);
+            [
+                'itemid' => $itemid,
+                'cmid' => $cmid
+            ]);
         $cm = get_coursemodule_from_id('publication', $params['cmid'], 0, false, MUST_EXIST);
         $course = $DB->get_record('course', ['id' => $cm->course], '*', MUST_EXIST);
         $context = context_module::instance($cm->id);
@@ -94,4 +94,226 @@ class mod_publication_external extends external_api {
     public static function get_onlinetextpreview_returns() {
         return new external_value(PARAM_RAW, 'HTML snippet representing the online text to use in overlay', VALUE_OPTIONAL, '');
     }
+
+    /**
+     * Returns description of the get_publications_by_courses parameters
+     *
+     * @return external_function_parameters
+     */
+    public static function get_publications_by_courses_parameters() {
+        return new external_function_parameters([
+            'courseids' => new external_multiple_structure(
+                new external_value(PARAM_INT, 'Course id'), 'Array of course ids (all enrolled courses if empty array)', VALUE_DEFAULT, []
+            ),
+        ]);
+    }
+
+    /**
+     * Returns description of the get_publications_by_courses result value
+     *
+     * @return external_single_structure
+     */
+    public static function get_publications_by_courses_returns() {
+        return new external_single_structure([
+            'publications' => new external_multiple_structure(self::publication_structure(), 'All publications for the given courses'),
+            'warnings' => new external_warnings()
+        ]);
+    }
+
+    /**
+     * Get all publications for the courses with the given ids. If the ids are empty all publications from all
+     * user-enrolled courses are returned.
+     *
+     * @param $courseids array the ids of the courses to get publications for (all user enrolled courses if empty array)
+     * @return stdClass
+     * @throws coding_exception
+     * @throws dml_exception
+     * @throws invalid_parameter_exception
+     * @throws moodle_exception
+     */
+    public static function get_publications_by_courses($courseids) {
+
+        $params = self::validate_parameters(self::get_publications_by_courses_parameters(), [
+            'courseids' => $courseids
+        ]);
+
+        $rpublications = [];
+        $warnings = [];
+
+        $mycourses = new stdClass();
+        if (empty($params['courseids'])) {
+            $mycourses = enrol_get_my_courses();
+            $params['courseids'] = array_keys($mycourses);
+        }
+
+        // Ensure there are courseids to loop through.
+        if (!empty($params['courseids'])) {
+
+            list($courses, $warnings) = external_util::validate_courses($params['courseids'], $mycourses);
+
+            // Get the publications in this course, this function checks users visibility permissions.
+            // We can avoid then additional validate_context calls.
+            $publication_instances = get_all_instances_in_courses("publication", $courses);
+            foreach ($publication_instances as $publication_instance) {
+
+                $cm = get_coursemodule_from_id('publication', $publication_instance->coursemodule);
+                $publication = new publication($cm);
+                $rpublications[] = self::export_publication($publication->get_instance());
+            }
+        }
+
+        $result = new stdClass();
+        $result->publications = $rpublications;
+        $result->warnings = $warnings;
+        return $result;
+    }
+
+
+    /**
+     * Returns description of the get_publication parameters
+     *
+     * @return external_function_parameters
+     */
+    public static function get_publication_parameters() {
+        return new external_function_parameters([
+            'publicationid' => new external_value(PARAM_INT, 'The id of the publication'),
+        ]);
+    }
+
+    /**
+     * Returns description of the get_publication result value
+     *
+     * @return external_single_structure
+     */
+    public static function get_publication_returns() {
+        return new external_single_structure([
+            'publication' => self::publication_structure(),
+        ]);
+    }
+
+    /**
+     * Returns the publication for the given id
+     *
+     * @param $publicationid
+     * @return stdClass
+     * @throws coding_exception
+     * @throws dml_exception
+     * @throws invalid_parameter_exception
+     * @throws moodle_exception
+     * @throws required_capability_exception
+     * @throws restricted_context_exception
+     */
+    public static function get_publication($publicationid) {
+        global $DB, $USER;
+
+        $params = self::validate_parameters(self::get_publication_parameters(), [
+            'publicationid' => $publicationid,
+        ]);
+
+        $cm = get_coursemodule_from_instance('publication', $params['publicationid'], 0, false, MUST_EXIST);
+
+        $context = context_module::instance($cm->id);
+        require_capability('mod/publication:view', $context);
+        self::validate_context($context);
+
+        $publication = new publication($cm);
+        $result = new stdClass();
+
+        $result->publication = self::export_publication($publication->get_instance());
+        $publication_files = $DB->get_records('publication_file', ['publication' => $publication->get_instance()->id], '', '*');
+
+        $files = [];
+        foreach ($publication_files as $index => $publication_file) {
+            if ($publication->has_filepermission($publication_file->fileid, $USER->id)) {
+                $files[] = $publication_file;
+            }
+        }
+
+        $result->publication->files = self::export_publication_files($files);
+
+        return $result;
+    }
+
+    /**
+     * Description of the publication structure in result values
+     *
+     * @return external_single_structure
+     */
+    private static function publication_structure() {
+        return new external_single_structure(
+            [
+                'id' => new external_value(PARAM_INT, 'publication id'),
+                'course' => new external_value(PARAM_INT, 'course id the publication belongs to'),
+                'name' => new external_value(PARAM_TEXT, 'publication name'),
+                'intro' => new external_value(PARAM_RAW, 'intro/description of the publication'),
+                'introformat' => new external_value(PARAM_INT, 'intro format'),
+                'files' => new external_multiple_structure(self::publication_file_structure(), 'files in this publication', VALUE_OPTIONAL),
+            ], 'publication information'
+        );
+    }
+
+    /**
+     * Description of the publication file structure in result values
+     *
+     * @return external_single_structure
+     */
+    private static function publication_file_structure() {
+        return new external_single_structure(
+            [
+                'id' => new external_value(PARAM_INT, 'file id'),
+                'name' => new external_value(PARAM_TEXT, 'file name'),
+                'mimetype' => new external_value(PARAM_TEXT, 'file mime type'),
+                'download_url' => new external_value(PARAM_RAW, 'download url for this file'),
+            ], 'publication file information'
+        );
+    }
+
+    /**
+     * Converts the given publication to match the publication structure for result values
+     *
+     * @param $publication object       The publication to be exported
+     * @return object                   The exported publication (confirms to publication structure)
+     */
+    private static function export_publication($publication) {
+        $result = new stdClass();
+
+        $result->id = $publication->id;
+        $result->course = $publication->course;
+        $result->name = $publication->name;
+        $result->intro = $publication->intro;
+        $result->introformat = $publication->introformat;
+
+        return $result;
+    }
+
+    /**
+     * Converts the given files to match the publication file structure for result values
+     *
+     * @param $files array              The files to be exported
+     * @return array                    The exported publication files (confirms to publication file structure)
+     */
+    private static function export_publication_files($files) {
+        $result_files = [];
+
+        $fs = get_file_storage();
+
+        foreach ($files as $index => $file_record) {
+            $result_file = new stdClass();
+
+            $file = $fs->get_file_by_id($file_record->fileid);
+
+            $result_file->id = $file->get_id();
+            $result_file->name = $file->get_filename();
+            $result_file->mimetype = $file->get_mimetype();
+            $result_file->download_url = moodle_url::make_webservice_pluginfile_url(
+                $file->get_contextid(), $file->get_component(), $file->get_filearea(),
+                $file->get_itemid(), $file->get_filepath(), $file->get_filename(), true
+            )->out(false);
+
+            $result_files[] = $result_file;
+        }
+
+        return $result_files;
+    }
+
 }

--- a/tests/externallib_test.php
+++ b/tests/externallib_test.php
@@ -1,0 +1,185 @@
+<?php
+
+use mod_publication\local\tests\base;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+
+require_once($CFG->dirroot . '/webservice/tests/helpers.php');
+require_once($CFG->dirroot . '/mod/publication/externallib.php');
+
+/**
+ * External mod publication functions unit tests
+ */
+class mod_publication_external_testcase extends base {
+    
+    /**
+     * Test if the user only gets publication for enrolled courses
+     */
+    public function test_get_publications_by_courses() {
+        global $CFG, $DB, $USER;
+
+        $this->resetAfterTest(true);
+
+        $user = $this->getDataGenerator()->create_user();
+
+        $course1 = $this->getDataGenerator()->create_course([
+            'fullname' => 'PHPUnitTestCourse1',
+            'summary' => 'Test course for automated php unit tests',
+            'summaryformat' => FORMAT_HTML
+        ]);
+
+        $this->getDataGenerator()->enrol_user($user->id, $course1->id);
+
+        $course2 = $this->getDataGenerator()->create_course([
+            'fullname' => 'PHPUnitTestCourse2',
+            'summary' => 'Test course for automated php unit tests',
+            'summaryformat' => FORMAT_HTML
+        ]);
+
+        $this->getDataGenerator()->enrol_user($user->id, $course2->id);
+
+        $course3 = $this->getDataGenerator()->create_course([
+            'fullname' => 'PHPUnitTestCourse3',
+            'summary' => 'Test course for automated php unit tests',
+            'summaryformat' => FORMAT_HTML
+        ]);
+
+        $publication1 = self::getDataGenerator()->create_module('publication', [
+            'course' => $course1->id,
+            'name' => 'Publication Module 1',
+            'intro' => 'Publication module for automated php unit tests',
+            'introformat' => FORMAT_HTML,
+        ]);
+
+        $publication2 = self::getDataGenerator()->create_module('publication', [
+            'course' => $course2->id,
+            'name' => 'Publication Module 2',
+            'intro' => 'Publication module for automated php unit tests',
+            'introformat' => FORMAT_HTML,
+        ]);
+
+        $publication3 = self::getDataGenerator()->create_module('publication', [
+            'course' => $course3->id,
+            'name' => 'Publication Module 3',
+            'intro' => 'Publication module for automated php unit tests',
+            'introformat' => FORMAT_HTML,
+        ]);
+
+        $this->setUser($user);
+
+        $result = mod_publication_external::get_publications_by_courses([]);
+
+        // user is enrolled only in course1 and course2, so the third publication module in course3 should not be included
+        $this->assertEquals(2, count($result->publications));
+    }
+
+
+    /**
+     * Test if the user gets a valid publication from the endpoint
+     */
+    public function test_get_publication() {
+        global $CFG, $DB, $USER;
+
+        $this->resetAfterTest(true);
+
+        $user = $this->getDataGenerator()->create_user();
+
+        $course = $this->getDataGenerator()->create_course([
+            'fullname' => 'PHPUnitTestCourse',
+            'summary' => 'Test course for automated php unit tests',
+            'summaryformat' => FORMAT_HTML
+        ]);
+
+        $this->getDataGenerator()->enrol_user($user->id, $course->id);
+
+        $publication = self::getDataGenerator()->create_module('publication', [
+            'course' => $course->id,
+            'name' => 'Publication Module',
+            'intro' => 'Publication module for automated php unit tests',
+            'introformat' => FORMAT_HTML,
+        ]);
+
+        $this->setUser($user);
+
+        $result = mod_publication_external::get_publication($publication->id);
+
+        // publication name should be equal to 'Publication Module'
+        $this->assertEquals('Publication Module', $result->publication->name);
+
+        // Course id in publication should be equal to the id of the course
+        $this->assertEquals($course->id, $result->publication->course);
+    }
+
+
+    /**
+     * Test if the user gets an exception when the publication is hidden in the course
+     */
+    public function test_get_publication_hidden() {
+        global $CFG, $DB, $USER;
+
+        $this->resetAfterTest(true);
+
+        $user = $this->getDataGenerator()->create_user();
+
+        $course = $this->getDataGenerator()->create_course([
+            'fullname' => 'PHPUnitTestCourse',
+            'summary' => 'Test course for automated php unit tests',
+            'summaryformat' => FORMAT_HTML
+        ]);
+
+        $this->getDataGenerator()->enrol_user($user->id, $course->id);
+
+        $publication = self::getDataGenerator()->create_module('publication', [
+            'course' => $course->id,
+            'name' => 'Hidden Publication Module',
+            'intro' => 'Publication module for automated php unit tests',
+            'introformat' => FORMAT_HTML,
+            'visible' => 0,
+        ]);
+
+        $this->setUser($user);
+
+        // Test should throw require_login_exception
+        $this->expectException(require_login_exception::class);
+
+        $result = mod_publication_external::get_publication($publication->id);
+
+    }
+
+    /**
+     * Test if the user gets some files from the publication
+     */
+    public function test_get_publication_files() {
+        global $CFG, $DB, $USER;
+
+        $this->resetAfterTest(true);
+
+        $user = $this->getDataGenerator()->create_user();
+
+        $course = $this->getDataGenerator()->create_course([
+            'fullname' => 'PHPUnitTestCourse',
+            'summary' => 'Test course for automated php unit tests',
+            'summaryformat' => FORMAT_HTML
+        ]);
+
+        $this->getDataGenerator()->enrol_user($user->id, $course->id);
+
+        $publication = self::getDataGenerator()->create_module('publication', [
+            'course' => $course->id,
+            'name' => 'Publication Module',
+            'intro' => 'Publication module for automated php unit tests',
+            'introformat' => FORMAT_HTML,
+        ]);
+
+        $this->setUser($user);
+
+        $this->create_upload($USER->id, $publication->id, 'test1.txt', 'Test 1');
+
+        $result = mod_publication_external::get_publication($publication->id);
+
+        $this->assertEquals($result->publication->files[0]->name, 'test1.txt');
+
+    }
+}


### PR DESCRIPTION
The publication can only be interacted with using a browser. This PR
solves this problem by providing moodle webservice endpoints.
Currently only student-relevant endpoints are available as this is our
goal. However, the webservices can be extended easily.

To provide webservice functions for the mod_publication plugin the
following additions were made:

- Added db/services.php which includes the description of the 2
  endpoints
- Added tests/externallib_test.php which includes unit tests for the
  endpoints
- Added externallib.php which includes the actual endpoints.

Following endpoints were added:

- mod_publication_get_publications_by_courses
- mod_publication_get_publication

_The collection of PRs posted by us, providing webservice functions, is supposed to serve the use-case of providing a student API for TUWEL (TU Wien Moodle Platform). It is with that purpose in mind, that we chose the plugins and the functionality to provide via web service. The following PRs are related to this effort:_
- [Checkmark](https://github.com/academic-moodle-cooperation/moodle-mod_checkmark/pull/65)
- [Grouptool](https://github.com/academic-moodle-cooperation/moodle-mod_grouptool/pull/23)
- [Offline-Quiz](https://github.com/academic-moodle-cooperation/moodle-mod_offlinequiz/pull/151)
- [Organizer](https://github.com/academic-moodle-cooperation/moodle-mod_organizer/pull/97)
- [Publication](https://github.com/academic-moodle-cooperation/moodle-mod_publication/pull/51)