### PR TITLE
Fix implode param order to work with PHP 8.0

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -359,7 +359,7 @@ class publication {
         $customusers = '';
 
         if (is_array($users) && count($users) > 0) {
-            $customusers = " and u.id IN (" . implode($users, ', ') . ") ";
+            $customusers = " and u.id IN (" . implode(', ', $users) . ") ";
         } else if ($users === false) {
             return [];
         }


### PR DESCRIPTION
Moodle 3.11 is now ready to run under PHP 8.0; plugins need to do so too.