### PR TITLE
Remove table borders in Moodle ≥ 5.0

### DIFF
--- a/classes/local/allfilestable/base.php
+++ b/classes/local/allfilestable/base.php
@@ -628,7 +628,7 @@ FROM
         list(, $files, ) = $this->get_files($values->id);
 
         $filetable = new \html_table();
-        $filetable->attributes = ['class' => 'filetable'];
+        $filetable->attributes = ['class' => 'filetable table-reboot'];
 
         foreach ($files as $file) {
             if (has_capability('mod/publication:approve', $this->context)
@@ -660,7 +660,7 @@ FROM
         list(, $files, ) = $this->get_files($values->id);
         global $OUTPUT;
         $filetable = new \html_table();
-        $filetable->attributes = ['class' => 'filetable'];
+        $filetable->attributes = ['class' => 'filetable table-reboot'];
 
         foreach ($files as $file) {
             if ((has_capability('mod/publication:approve', $this->context))
@@ -698,7 +698,7 @@ FROM
         list(, $files, ) = $this->get_files($values->id);
 
         $table = new \html_table();
-        $table->attributes = ['class' => 'statustable'];
+        $table->attributes = ['class' => 'statustable table-reboot'];
 
         foreach ($files as $file) {
             if (has_capability('mod/publication:approve', $this->context)
@@ -771,7 +771,7 @@ FROM
         list(, $files, ) = $this->get_files($values->id);
 
         $table = new \html_table();
-        $table->attributes = ['class' => 'statustable'];
+        $table->attributes = ['class' => 'statustable table-reboot'];
 
         foreach ($files as $file) {
             if ($this->publication->has_filepermission($file->get_id())) {
@@ -794,7 +794,7 @@ FROM
         list(, $files, ) = $this->get_files($values->id);
 
         $table = new \html_table();
-        $table->attributes = ['class' => 'statustable'];
+        $table->attributes = ['class' => 'statustable table-reboot'];
 
         foreach ($files as $file) {
             $row = [];


### PR DESCRIPTION
Note this uses Moodle 5.0.3.
The necessary .table-reboot table class comes with that version.

That would be those unnecessary borders here:

<img width="1393" height="172" alt="image" src="https://github.com/user-attachments/assets/2bc50140-6cc8-467f-9265-78002e01779a" />
